### PR TITLE
install by default in `gro sync`

### DIFF
--- a/.changeset/many-paws-notice.md
+++ b/.changeset/many-paws-notice.md
@@ -1,0 +1,5 @@
+---
+"@ryanatkn/gro": patch
+---
+
+add `install`/`no-install` args to `gro check` and `gro dev`

--- a/.changeset/sharp-snails-shout.md
+++ b/.changeset/sharp-snails-shout.md
@@ -1,0 +1,5 @@
+---
+"@ryanatkn/gro": minor
+---
+
+install by default in `gro sync`

--- a/.changeset/tall-radios-push.md
+++ b/.changeset/tall-radios-push.md
@@ -1,0 +1,5 @@
+---
+"@ryanatkn/gro": minor
+---
+
+rename `gro changeset` arg `dep` from `install`

--- a/src/lib/build.task.ts
+++ b/src/lib/build.task.ts
@@ -7,7 +7,7 @@ import {clean_fs} from './clean_fs.js';
 export const Args = z
 	.object({
 		install: z.boolean({description: 'dual of no-install'}).default(true),
-		'no-install': z
+		'no-install': z // convenience, same as `gro build -- gro sync --no-install` but the latter takes precedence
 			.boolean({description: 'opt out of npm installing before building'})
 			.default(false),
 	})

--- a/src/lib/build.task.ts
+++ b/src/lib/build.task.ts
@@ -8,7 +8,7 @@ export const Args = z
 	.object({
 		install: z.boolean({description: 'dual of no-install'}).default(true),
 		'no-install': z // convenience, same as `gro build -- gro sync --no-install` but the latter takes precedence
-			.boolean({description: 'opt out of npm installing before building'})
+			.boolean({description: 'opt out of `npm install` before building'})
 			.default(false),
 	})
 	.strict();

--- a/src/lib/changeset.task.ts
+++ b/src/lib/changeset.task.ts
@@ -33,10 +33,10 @@ export const Args = z
 			"changeset 'access' config value, the default depends on package.json#private",
 		).optional(),
 		changelog: z
-			.string({description: 'changeset "changelog" config value'})
+			.string({description: 'changelog dep package name, used as changeset\'s "changelog" config'})
 			.default('@changesets/changelog-git'),
-		install: z.boolean({description: 'dual of no-install'}).default(true),
-		'no-install': z
+		dep: z.boolean({description: 'dual of no-dep'}).default(true),
+		'no-dep': z
 			.boolean({description: 'opt out of npm installing the changelog package'})
 			.default(false),
 		origin: Git_Origin.describe('git origin to deploy to').default('origin'),
@@ -60,7 +60,7 @@ export const task: Task<Args> = {
 	run: async (ctx): Promise<void> => {
 		const {
 			invoke_task,
-			args: {_, minor, major, dir, access: access_arg, changelog, install, origin, changeset_cli},
+			args: {_, minor, major, dir, access: access_arg, changelog, dep, origin, changeset_cli},
 			log,
 			sveltekit_config,
 		} = ctx;
@@ -111,13 +111,13 @@ export const task: Task<Args> = {
 
 			await spawn('git', ['add', dir]);
 
-			if (install) {
+			if (dep) {
 				await spawn('npm', ['i', '-D', changelog]);
 			}
 		}
 
 		// TODO small problem here where generated files don't get committed
-		await invoke_task('sync', {install: false}); // after the `npm i` above, and in all cases
+		await invoke_task('sync', {install: inited || !dep}); // after the `npm i` above, and in all cases
 
 		if (message) {
 			// TODO see the helper below, simplify this to CLI flags when support is added to Changesets

--- a/src/lib/changeset.task.ts
+++ b/src/lib/changeset.task.ts
@@ -117,7 +117,7 @@ export const task: Task<Args> = {
 		}
 
 		// TODO small problem here where generated files don't get committed
-		await invoke_task('sync'); // after the `npm i` above, and in all cases
+		await invoke_task('sync', {install: false}); // after the `npm i` above, and in all cases
 
 		if (message) {
 			// TODO see the helper below, simplify this to CLI flags when support is added to Changesets

--- a/src/lib/check.task.ts
+++ b/src/lib/check.task.ts
@@ -23,7 +23,7 @@ export const Args = z
 		sync: z.boolean({description: 'dual of no-sync'}).default(true),
 		'no-sync': z.boolean({description: 'opt out of syncing'}).default(false),
 		install: z.boolean({description: 'dual of no-install'}).default(true),
-		'no-install': z.boolean({description: 'opt out of npm install when syncing'}).default(false), // convenience, same as `gro check -- gro sync --no-install` but the latter takes precedence
+		'no-install': z.boolean({description: 'opt out of `npm install` when syncing'}).default(false), // convenience, same as `gro check -- gro sync --no-install` but the latter takes precedence
 		workspace: z
 			.boolean({description: 'ensure a clean git workspace, useful for CI, also implies --no-sync'})
 			.default(false),

--- a/src/lib/check.task.ts
+++ b/src/lib/check.task.ts
@@ -22,6 +22,8 @@ export const Args = z
 		'no-lint': z.boolean({description: 'opt out of linting'}).default(false),
 		sync: z.boolean({description: 'dual of no-sync'}).default(true),
 		'no-sync': z.boolean({description: 'opt out of syncing'}).default(false),
+		install: z.boolean({description: 'dual of no-install'}).default(true),
+		'no-install': z.boolean({description: 'opt out of npm install when syncing'}).default(false), // convenience, same as `gro check -- gro sync --no-install` but the latter takes precedence
 		workspace: z
 			.boolean({description: 'ensure a clean git workspace, useful for CI, also implies --no-sync'})
 			.default(false),
@@ -33,12 +35,12 @@ export const task: Task<Args> = {
 	summary: 'check that everything is ready to commit',
 	Args,
 	run: async ({args, invoke_task, log, config}) => {
-		const {typecheck, test, gen, format, package_json, lint, sync, workspace} = args;
+		const {typecheck, test, gen, format, package_json, lint, sync, install, workspace} = args;
 
 		// When checking the workspace, which was added for CI, never sync.
 		// Setup like `npm i` and `sveltekit-sync` should be done in the CI setup.
 		if (sync && !workspace) {
-			await invoke_task('sync', {gen: false}); // never generate because `gro gen --check` runs below
+			await invoke_task('sync', {install, gen: false}); // never generate because `gro gen --check` runs below
 		}
 
 		if (typecheck) {

--- a/src/lib/dev.task.ts
+++ b/src/lib/dev.task.ts
@@ -15,6 +15,10 @@ export const Args = z
 			.default(false),
 		sync: z.boolean({description: 'dual of no-sync'}).default(true),
 		'no-sync': z.boolean({description: 'opt out of gro sync'}).default(false),
+		install: z.boolean({description: 'dual of no-install'}).default(true),
+		'no-install': z // convenience, same as `gro dev -- gro sync --no-install` but the latter takes precedence
+			.boolean({description: 'opt out of `npm install` before starting the dev server'})
+			.default(false),
 	})
 	.strict();
 export type Args = z.infer<typeof Args>;
@@ -26,12 +30,12 @@ export const task: Task<Args> = {
 	Args,
 	run: async (ctx) => {
 		const {args, invoke_task} = ctx;
-		const {watch, sync} = args;
+		const {watch, sync, install} = args;
 
 		await clean_fs({build_dev: true});
 
 		if (sync) {
-			await invoke_task('sync');
+			await invoke_task('sync', {install});
 		}
 
 		const plugins = await Plugins.create({...ctx, dev: true, watch});

--- a/src/lib/sync.task.ts
+++ b/src/lib/sync.task.ts
@@ -12,9 +12,9 @@ export const Args = z
 		package_json: z.boolean({description: 'dual of no-package_json'}).default(true),
 		'no-package_json': z.boolean({description: 'opt out of package.json sync'}).default(false),
 		gen: z.boolean({description: 'dual of no-gen'}).default(true),
-		'no-gen': z.boolean({description: 'opt out of gen sync'}).default(false),
+		'no-gen': z.boolean({description: 'opt out of running gen'}).default(false),
 		install: z.boolean({description: 'dual of no-install'}).default(true),
-		'no-install': z.boolean({description: 'opt out of npm install'}).default(false),
+		'no-install': z.boolean({description: 'opt out of `npm install`'}).default(false),
 	})
 	.strict();
 export type Args = z.infer<typeof Args>;

--- a/src/lib/sync.task.ts
+++ b/src/lib/sync.task.ts
@@ -13,7 +13,8 @@ export const Args = z
 		'no-package_json': z.boolean({description: 'opt out of package.json sync'}).default(false),
 		gen: z.boolean({description: 'dual of no-gen'}).default(true),
 		'no-gen': z.boolean({description: 'opt out of gen sync'}).default(false),
-		install: z.boolean({description: 'run npm install'}).default(false),
+		install: z.boolean({description: 'dual of no-install'}).default(true),
+		'no-install': z.boolean({description: 'opt out of npm install'}).default(false),
 	})
 	.strict();
 export type Args = z.infer<typeof Args>;

--- a/src/lib/upgrade.task.ts
+++ b/src/lib/upgrade.task.ts
@@ -68,7 +68,7 @@ export const task: Task<Args> = {
 		await spawn('npm', install_args);
 
 		// Sync in a new process to pick up any changes after installing, avoiding some errors.
-		await spawn_cli('gro', ['sync']);
+		await spawn_cli('gro', ['sync', '--no-install']); // don't install because we do above
 	},
 };
 

--- a/src/lib/upgrade.task.ts
+++ b/src/lib/upgrade.task.ts
@@ -58,16 +58,13 @@ export const task: Task<Args> = {
 		log.info(`upgrading:`, upgrade_items.join(' '));
 
 		const install_args = ['install'].concat(upgrade_items);
-
 		if (dry) {
 			install_args.push('--dry-run');
 			log.info(`deps`, deps);
 		}
-
 		if (force) {
 			install_args.push('--force');
 		}
-
 		await spawn('npm', install_args);
 
 		// Sync in a new process to pick up any changes after installing, avoiding some errors.


### PR DESCRIPTION
Seems like it's more convenient and less error prone to just make `gro sync` run `npm i` by default, it's fast when cached.