### PR TITLE
fix aliased imports from sibling dirs

### DIFF
--- a/.changeset/red-chicken-sell.md
+++ b/.changeset/red-chicken-sell.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/gro': patch
+---
+
+fix aliased imports from sibling dirs in the loader

--- a/src/lib/loader.ts
+++ b/src/lib/loader.ts
@@ -213,7 +213,7 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
 			parent_path ??= fileURLToPath(parent_url);
 			if (!parent_path.startsWith(dir)) {
 				// TODO BLOCK find the nearest sveltekit config and use that as the base?  and below, the nearest node_modules?
-				// TODO BLOCK also problem is the local sveltekit config may not be the one associated with this module!
+				// TODO BLOCK also problem is the local sveltekit config may not be the one associated with this cwd
 				final_dir;
 			}
 			console.log(`context`, context);

--- a/src/lib/loader.ts
+++ b/src/lib/loader.ts
@@ -213,6 +213,7 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
 			parent_path ??= fileURLToPath(parent_url);
 			if (!parent_path.startsWith(dir)) {
 				// TODO BLOCK find the nearest sveltekit config and use that as the base?  and below, the nearest node_modules?
+				// TODO BLOCK also problem is the local sveltekit config may not be the one associated with this module!
 				final_dir;
 			}
 			console.log(`context`, context);

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,6 +1,6 @@
 import {join, extname, relative, basename} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {strip_end} from '@ryanatkn/belt/string.js';
+import {ensure_end, strip_end} from '@ryanatkn/belt/string.js';
 import {gray} from '@ryanatkn/belt/styletext.js';
 
 import {
@@ -36,7 +36,7 @@ export interface Paths {
 
 export const create_paths = (root_dir: string): Paths => {
 	// TODO remove reliance on trailing slash towards windows support
-	const root = strip_end(root_dir, '/') + '/';
+	const root = ensure_end(root_dir, '/');
 	return {
 		root,
 		source: root + SOURCE_DIR,

--- a/src/lib/typecheck.task.ts
+++ b/src/lib/typecheck.task.ts
@@ -41,7 +41,7 @@ export const task: Task<Args> = {
 		const found_typescript_cli = find_cli(typescript_cli);
 		if (found_typescript_cli) {
 			const forwarded = to_forwarded_args(typescript_cli);
-			if (!forwarded.noEmit) forwarded.noEmit = true;
+			forwarded.noEmit = true;
 			const serialized = serialize_args(forwarded);
 			const svelte_check_result = await spawn_cli(found_typescript_cli, serialized, log);
 			if (!svelte_check_result?.ok) {


### PR DESCRIPTION
Currently we're using the cwd's SvelteKit config to resolve paths, but that breaks if you run tasks from other roots, like `gro run ../other_project/src/lib/thing.task.ts`, if `thing.task.ts` uses aliased imports. It works if they're relative or absolute.

It seems the correct behavior would be to load the correct SvelteKit config. Maybe this isn't worth it if it slows down the normal case significantly. I think we could be fast enough with smart caching, but I don't even have this usecase, so not now.