### PR TITLE
add `pm_cli` config

### DIFF
--- a/.changeset/silver-suits-give.md
+++ b/.changeset/silver-suits-give.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/gro': patch
+---
+
+add `pm_cli` config

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -47,6 +47,7 @@ export interface Gro_Config {
 	map_package_json: Map_Package_Json | null;
 	task_root_dirs: Path_Id[];
 	search_filters: Path_Filter[];
+	pm_cli: string;
 }
 
 // The relaxed variant that users can provide. Superset of `Gro_Config`.
@@ -55,6 +56,7 @@ export interface Raw_Gro_Config {
 	map_package_json?: Map_Package_Json | null;
 	task_root_dirs?: string[];
 	search_filters?: Path_Filter | Path_Filter[] | null;
+	pm_cli?: string;
 }
 ```
 
@@ -108,6 +110,7 @@ const config = create_empty_gro_config();
 // config.map_package_json = ...;
 // config.task_root_dirs = ...;
 // config.search_filters = ...;
+// config.pm_cli = ...;
 
 export default config;
 ```
@@ -208,3 +211,8 @@ Directories and files are included if they pass all of these filters.
 By default, it uses the `DEFAULT_SEARCH_EXCLUDER` to exclude
 dot-prefixed directories, node_modules,
 and the build and dist directories for SvelteKit and Gro.
+
+## `pm_cli`
+
+The CLI to use that's compatible with `npm install` and `npm link`.
+Defaults to `'npm'`.

--- a/src/lib/changeset.task.ts
+++ b/src/lib/changeset.task.ts
@@ -63,6 +63,7 @@ export const task: Task<Args> = {
 			args: {_, minor, major, dir, access: access_arg, changelog, dep, origin, changeset_cli},
 			log,
 			sveltekit_config,
+			config,
 		} = ctx;
 
 		const message = _.join(' ');
@@ -114,7 +115,7 @@ export const task: Task<Args> = {
 			await spawn('git', ['add', dir]);
 
 			if (dep) {
-				await spawn('npm', ['i', '-D', changelog]);
+				await spawn(config.pm_cli, ['i', '-D', changelog]);
 			}
 		}
 

--- a/src/lib/gro_config.ts
+++ b/src/lib/gro_config.ts
@@ -40,6 +40,10 @@ export interface Gro_Config {
 	 * directories and files are included if they pass all of these filters.
 	 */
 	search_filters: Path_Filter[];
+	/**
+	 * The CLI to use that's compatible with `npm install` and `npm link`. Defaults to `'npm'`.
+	 */
+	pm_cli: string;
 }
 
 /**
@@ -52,6 +56,7 @@ export interface Raw_Gro_Config {
 	map_package_json?: Map_Package_Json | null;
 	task_root_dirs?: string[];
 	search_filters?: Path_Filter | Path_Filter[] | null;
+	pm_cli?: string;
 }
 
 export type Create_Gro_Config = (
@@ -68,6 +73,7 @@ export const create_empty_gro_config = (): Gro_Config => ({
 		IS_THIS_GRO ? null : GRO_DIST_DIR,
 	].filter((v) => v !== null),
 	search_filters: [(id) => !DEFAULT_SEARCH_EXCLUDER.test(id)],
+	pm_cli: 'npm',
 });
 
 /**
@@ -112,6 +118,7 @@ export const normalize_gro_config = (raw_config: Raw_Gro_Config): Gro_Config => 
 		map_package_json = empty_config.map_package_json,
 		task_root_dirs = empty_config.task_root_dirs,
 		search_filters = empty_config.search_filters,
+		pm_cli = empty_config.pm_cli,
 	} = raw_config;
 	return {
 		plugins,
@@ -122,6 +129,7 @@ export const normalize_gro_config = (raw_config: Raw_Gro_Config): Gro_Config => 
 			: search_filters
 				? [search_filters]
 				: [],
+		pm_cli,
 	};
 };
 

--- a/src/lib/gro_plugin_sveltekit_library.ts
+++ b/src/lib/gro_plugin_sveltekit_library.ts
@@ -38,7 +38,7 @@ export const gro_plugin_sveltekit_library = ({
 
 			// `npm link`
 			if (package_json.bin) {
-				const timing_to_npm_link = timings.start('npm link');
+				const timing_to_link = timings.start(`${config.pm_cli} link`);
 				await Promise.all(
 					Object.values(package_json.bin).map(async (bin_path) => {
 						const chmod_result = await spawn('chmod', ['+x', bin_path]);
@@ -51,7 +51,7 @@ export const gro_plugin_sveltekit_library = ({
 				if (!link_result.ok) {
 					throw new Task_Error(`Failed to link. ${print_spawn_result(link_result)}`);
 				}
-				timing_to_npm_link();
+				timing_to_link();
 			}
 		},
 	};

--- a/src/lib/gro_plugin_sveltekit_library.ts
+++ b/src/lib/gro_plugin_sveltekit_library.ts
@@ -33,7 +33,7 @@ export const gro_plugin_sveltekit_library = ({
 				await run_svelte_package(svelte_package_options, svelte_package_cli, log);
 			}
 		},
-		adapt: async ({log, timings}) => {
+		adapt: async ({log, timings, config}) => {
 			const package_json = load_package_json();
 
 			// `npm link`
@@ -47,7 +47,7 @@ export const gro_plugin_sveltekit_library = ({
 					}),
 				);
 				log.info(`linking`);
-				const link_result = await spawn('npm', ['link', '-f']); // TODO don't use `-f` unless necessary or at all?
+				const link_result = await spawn(config.pm_cli, ['link', '-f']); // TODO don't use `-f` unless necessary or at all?
 				if (!link_result.ok) {
 					throw new Task_Error(`Failed to link. ${print_spawn_result(link_result)}`);
 				}

--- a/src/lib/publish.task.ts
+++ b/src/lib/publish.task.ts
@@ -133,9 +133,9 @@ export const task: Task<Args> = {
 
 			// This is the first line that alters the repo.
 
-			const npmVersionResult = await spawn_cli(found_changeset_cli, ['version'], log);
-			if (!npmVersionResult?.ok) {
-				throw Error('npm version failed: no commits were made: see the error above');
+			const changeset_ersion_result = await spawn_cli(found_changeset_cli, ['version'], log);
+			if (!changeset_ersion_result?.ok) {
+				throw Error('changeset version failed: no commits were made: see the error above');
 			}
 
 			if (!preserve_changelog) {

--- a/src/lib/publish.task.ts
+++ b/src/lib/publish.task.ts
@@ -6,7 +6,6 @@ import {existsSync} from 'node:fs';
 import {Task_Error, type Task} from './task.js';
 import {load_package_json, parse_repo_url} from './package_json.js';
 import {find_cli, spawn_cli} from './cli.js';
-import {IS_THIS_GRO} from './paths.js';
 import {has_sveltekit_library} from './sveltekit_helpers.js';
 import {update_changelog} from './changelog.js';
 import {load_from_env} from './env.js';
@@ -82,11 +81,6 @@ export const task: Task<Args> = {
 			throw new Task_Error(
 				'Failed to find SvelteKit library: ' + has_sveltekit_library_result.message,
 			);
-		}
-
-		// TODO hacky, ensures Gro bootstraps itself
-		if (IS_THIS_GRO) {
-			await spawn('npm', ['run', 'build']);
 		}
 
 		const changelog_exists = existsSync(changelog);

--- a/src/lib/reinstall.task.ts
+++ b/src/lib/reinstall.task.ts
@@ -11,9 +11,9 @@ export type Args = z.infer<typeof Args>;
 export const task: Task<Args> = {
 	summary: `refreshes ${LOCKFILE_FILENAME} with the latest and cleanest deps`,
 	Args,
-	run: async ({log}): Promise<void> => {
+	run: async ({log, config}): Promise<void> => {
 		log.info('running the initial npm install');
-		const initial_install_result = await spawn('npm', ['i']);
+		const initial_install_result = await spawn(config.pm_cli, ['i']);
 		if (!initial_install_result.ok) {
 			throw new Task_Error('Failed initial npm install');
 		}
@@ -23,7 +23,7 @@ export const task: Task<Args> = {
 		log.info(
 			`running npm install after deleting ${LOCKFILE_FILENAME} and ${NODE_MODULES_DIRNAME}, this can take a while...`,
 		);
-		const second_install_result = await spawn('npm', ['i']);
+		const second_install_result = await spawn(config.pm_cli, ['i']);
 		if (!second_install_result.ok) {
 			throw new Task_Error(
 				`Failed npm install after deleting ${LOCKFILE_FILENAME} and ${NODE_MODULES_DIRNAME}`,
@@ -34,7 +34,7 @@ export const task: Task<Args> = {
 		// like esbuild's many packages for each platform.
 		await rm(LOCKFILE_FILENAME);
 		log.info(`running npm install one last time to clean ${LOCKFILE_FILENAME}`);
-		const final_install_result = await spawn('npm', ['i']);
+		const final_install_result = await spawn(config.pm_cli, ['i']);
 		if (!final_install_result.ok) {
 			throw new Task_Error('Failed npm install');
 		}

--- a/src/lib/sync.task.ts
+++ b/src/lib/sync.task.ts
@@ -26,7 +26,7 @@ export const task: Task<Args> = {
 		const {sveltekit, package_json, gen, install} = args;
 
 		if (install) {
-			const result = await spawn('npm', ['i']);
+			const result = await spawn(config.pm_cli, ['i']);
 			if (!result.ok) {
 				throw new Task_Error('Failed npm install');
 			}

--- a/src/lib/upgrade.task.ts
+++ b/src/lib/upgrade.task.ts
@@ -28,7 +28,7 @@ export type Args = z.infer<typeof Args>;
 export const task: Task<Args> = {
 	summary: 'upgrade deps',
 	Args,
-	run: async ({args, log}): Promise<void> => {
+	run: async ({args, log, config}): Promise<void> => {
 		const {_, only, origin, force, pull, dry} = args;
 
 		if (_.length && only.length) {
@@ -66,8 +66,8 @@ export const task: Task<Args> = {
 		if (force) {
 			install_args.push('--force');
 		}
-		install_args.push(...serialize_args(to_forwarded_args('npm')));
-		await spawn('npm', install_args);
+		install_args.push(...serialize_args(to_forwarded_args(config.pm_cli)));
+		await spawn(config.pm_cli, install_args);
 
 		// Sync in a new process to pick up any changes after installing, avoiding some errors.
 		await spawn_cli('gro', ['sync', '--no-install']); // don't install because we do above


### PR DESCRIPTION
Makes Gro compatible with non-npm package managers that have compatible `install` and `link` commands.